### PR TITLE
ValidateOperation: move return to outer scope

### DIFF
--- a/d1-calculator/Program.cs
+++ b/d1-calculator/Program.cs
@@ -106,10 +106,8 @@ namespace ConsoleApp2
             {
                 System.Environment.Exit(0); // exit at user's command
             }
-            else
-            {
-                return input; // continue to calculate
-            }
+
+            return input; // continue to calculate
         }
 
 


### PR DESCRIPTION
return statement was in 'if' block of 'if/else', and 'else' block had no return - compile exception on TA's machine